### PR TITLE
Pipe stderr until chrome opened

### DIFF
--- a/nif
+++ b/nif
@@ -15,7 +15,7 @@ function onstderrData(d) {
   // please. Thanks :)
   const lines = d.toString().split('\n')
   const url = lines.filter(x => x.trim().length).pop()
-  if (!/chrome-devtools[:]\/\//.test(url)) return
+  if (!/chrome-devtools[:]\/\//.test(url)) return process.stderr.write(d)
   opened = true
   spawn('chrome-cli', [ 'open', url ], { stdio: 'inherit' })
 }


### PR DESCRIPTION
I got an error log from the node process because it couldn't allocate the port.
```
Unable to open devtools socket: address already in use
```
The executable swallowed all errors and I didn't see anything until I patched the lib.