### PR TITLE
Exit when chrome cli is missing

### DIFF
--- a/nif
+++ b/nif
@@ -1,6 +1,12 @@
 #!/usr/bin/env node
+const { spawn, execSync } = require('child_process')
 
-const { spawn } = require('child_process')
+try {
+  execSync('which chrome-cli', { env: process.env, stdio: 'ignore' })
+} catch (err) {
+  console.error('No chrome-cli executable found. Please install it using \nbrew install chrome-cli')
+  process.exit(1)
+}
 
 const args = [ '--inspect', '--debug-brk' ].concat(process.argv.slice(2))
 const { stderr } = spawn(process.execPath, args)


### PR DESCRIPTION
While I'm at it, I can also add a check.
I was too lazy and didn't read the readme good enough. 😉

With this change, the executable exits when `chrome-cli` is missing.
e.g.
```bash
$ nif index.js
No chrome-cli executable found. Please install it using 
brew install chrome-cli
```

I guess it's good enough to just use execSync to check the existence of the `chrome-cli` executable.
